### PR TITLE
Name changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ requests](#submitting-pull-requests), but please respect the following restricti
 has already reported your problem or requested your idea.
 
 * Please **do not** use the issue tracker for personal support requests (use
-  [the github issues](http://github.com/butterproject/butter/issues) or IRC - #butterproject on freenode).
+  [the github issues](http://github.com/butterproject/butter-desktop/issues) or IRC - #butterproject on freenode).
 
 * Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
@@ -40,7 +40,7 @@ Guidelines for bug reports:
 
 1. **Use the GitHub issue search** &mdash; check if the issue has already been reported.
 
-2. **Check if the issue has been fixed** &mdash; try to reproduce it using the latest `master` or look for [closed issues](https://github.com/butterproject/butter/issues?q=is%3Aissue+is%3Aclosed).
+2. **Check if the issue has been fixed** &mdash; try to reproduce it using the latest `master` or look for [closed issues](https://github.com/butterproject/butter-desktop/issues?q=is%3Aissue+is%3Aclosed).
 
 3. **Include a screencast if relevant** - Is your issue about a design or front end feature or bug? The most helpful thing in the world is if we can *see* what you're talking about.
 Use [LICEcap](http://www.cockos.com/licecap/) to quickly and easily record a short screencast (24fps) and save it as an animated gif! Embed it directly into your GitHub issue. Kapow.
@@ -78,8 +78,8 @@ Any other information you want to share that is relevant to the issue being repo
 
 Feature requests are welcome. Before you submit one be sure to have:
 
-1. Read the [Roadmap](https://github.com/butterproject/butter/tree/master/docs/RoadMap.md) and
-[Planned Features](https://github.com/butterproject/butter/tree/master/docs/Planned-Features.md) listing, **use the Github Issues search** and check the feature hasn't already been requested.
+1. Read the [Roadmap](https://github.com/butterproject/butter-desktop/tree/master/docs/RoadMap.md) and
+[Planned Features](https://github.com/butterproject/butter-desktop/tree/master/docs/Planned-Features.md) listing, **use the Github Issues search** and check the feature hasn't already been requested.
 2. Take a moment to think about whether your idea fits with the scope and aims of the project, or if it might
 better fit being an app/plugin.
 3. Remember, it's up to *you* to make a strong case to convince the project's leaders of the merits of this
@@ -105,15 +105,15 @@ what's already there? Does it fit with the Roadmap?
 Pull requests are awesome. If you're looking to raise a PR for something which doesn't have an open issue, please think carefully about [raising an issue](#report-a-bug) which your PR can close, especially if you're fixing a bug. This makes it more likely that there will be enough information available for your PR to be properly tested and merged. To make sure your PR is accepted as quickly as possible, you should be sure to have read
 all the guidelines on:
 
-* [code standards](https://github.com/butterproject/butter/tree/master/docs/Code-Standards.md)
-* [commit messages](https://github.com/butterproject/butter/tree/master/docs/Git-Workflow.md#commit-messages)
-* [cleaning-up history](https://github.com/butterproject/butter/tree/master/docs/Git-Workflow.md#clean-up-history)
-* [not breaking the build](https://github.com/butterproject/butter/tree/master/docs/Git-Workflow.md#check-it-passes-the-tests)
+* [code standards](https://github.com/butterproject/butter-desktop/tree/master/docs/Code-Standards.md)
+* [commit messages](https://github.com/butterproject/butter-desktop/tree/master/docs/Git-Workflow.md#commit-messages)
+* [cleaning-up history](https://github.com/butterproject/butter-desktop/tree/master/docs/Git-Workflow.md#clean-up-history)
+* [not breaking the build](https://github.com/butterproject/butter-desktop/tree/master/docs/Git-Workflow.md#check-it-passes-the-tests)
 
 ##### Need Help?
 
 If you're not completely clear on how to submit / update / *do* Pull Requests, please check out our in depth
-[Git Workflow guide](https://github.com/butterproject/butter/tree/master/docs/Git-Workflow.md) for Butter.
+[Git Workflow guide](https://github.com/butterproject/butter-desktop/tree/master/docs/Git-Workflow.md) for Butter.
 
 
 ### Translation
@@ -134,7 +134,7 @@ For translations please go to: [Transifex](https://www.transifex.com/butterproje
 1. cd into the project folder
 1. Run `npm install -g grunt-cli bower` - to make it possible to run grunt commands
 
-[complete documentation](https://github.com/butterproject/butter/tree/master/docs/Build-Debug.md).
+[complete documentation](https://github.com/butterproject/butter-desktop/tree/master/docs/Build-Debug.md).
 
 ### Updating with the latest changes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # [Butter](https://github.com/butterproject/butter-desktop)
 
 [![Build Status](https://travis-ci.org/butterproject/butter-desktop.svg?branch=master)](https://travis-ci.org/butterproject/butter-desktop)
+[![Dependency Status](https://david-dm.org/butterproject/butter-desktop.svg)](https://david-dm.org/butterproject/butter-desktop)
+[![devDependency Status](https://david-dm.org/butterproject/butter-desktop/dev-status.svg)](https://david-dm.org/butterproject/butter-desktop#info=devDependencies)
 
 Allow any user to easily watch movies through torrent streaming, without any prerequisites.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# [Butter](https://github.com/butterproject/butter)
+# [Butter](https://github.com/butterproject/butter-desktop)
 
-[![Build Status](https://travis-ci.org/butterproject/butter.svg?branch=master)](https://travis-ci.org/butterproject/butter)
+[![Build Status](https://travis-ci.org/butterproject/butter-desktop.svg?branch=master)](https://travis-ci.org/butterproject/butter-desktop)
 
 Allow any user to easily watch movies through torrent streaming, without any prerequisites.
 
@@ -18,7 +18,7 @@ If you're comfortable getting up and running from a `git clone`, this method is 
 
 If you clone the GitHub repository, you will need to build a number of assets using grunt.
 
-The [master](https://github.com/butterproject/butter) branch which contains the latest release.
+The [master](https://github.com/butterproject/butter-desktop) branch which contains the latest release.
 
 #### Quickstart:
 

--- a/dist/linux/deb-maker.sh
+++ b/dist/linux/deb-maker.sh
@@ -101,7 +101,7 @@ Description: $projectName
 echo "Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0
 Upstream-Name: $projectName
 Upstream-Contact: $projectName Project <butter@xaiki.net>
-Source: https://github.com/butterproject/butter
+Source: https://github.com/butterproject/butter-desktop
 
 Files: *
 Copyright: © 2015, $projectName Project and the contributors <butter@xaiki.net>

--- a/dist/linux/exec_basefile.sh
+++ b/dist/linux/exec_basefile.sh
@@ -24,7 +24,7 @@ func_error
 
 #Variables
 version="BT_VERSION"
-tos="https://butterproject.github.io/tos.html"
+tos="http://butterproject.org/tos.html"
 
 #Disclaimer
 clear

--- a/dist/linux/package-information
+++ b/dist/linux/package-information
@@ -129,7 +129,7 @@ binary: binary-indep binary-arch
 #A text file formatted following http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 copyright="Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Butter
-Source: https://github.com/butterproject/butter
+Source: https://github.com/butterproject/butter-desktop
 
 Files: *
 Copyright: 2014 Butter Project and the contributors <butter@xaiki.net>

--- a/make_butter.sh
+++ b/make_butter.sh
@@ -10,15 +10,15 @@
 ## If you use 'ssh' in the place of the optional [url] parameter, it will clone via ssh instead of http
 ##
 ## Optionally, you can also pass in a specific branch to build or clone, by making url contain a branch specifier
-## ./make_butter.sh '-b release/0.3.4 https://github.com/butterproject/butter'
+## ./make_butter.sh '-b release/0.3.4 https://github.com/butterproject/butter-desktop'
 ##
 
 
 clone_repo="True"
 if [ -z "$1" ]; then
-    clone_url="https://github.com/butterproject/butter.git"
+    clone_url="https://github.com/butterproject/butter-desktop.git"
 elif [ "$1" = "ssh" ]; then
-    clone_url="ssh://git@github.com:butterproject/butter.git"
+    clone_url="ssh://git@github.com:butterproject/butter-desktop.git"
 else
     clone_url="$1"
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Butter",
-  "homepage": "https://butterproject.github.com/butter",
+  "homepage": "http://butterproject.org/",
   "bugs": "https://github.com/butterproject/butter-desktop/issues",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "Butter",
   "homepage": "https://butterproject.github.com/butter",
-  "bugs": "https://github.com/butterproject/butter/issues",
+  "bugs": "https://github.com/butterproject/butter-desktop/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/butterproject/butter.git"
+    "url": "https://github.com/butterproject/butter-desktop.git"
   },
   "license": "GPL-3.0",
   "main": "app://host/src/app/index.html",

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -5,11 +5,11 @@ var Settings = {
     projectTwitter: 'butterproject',
     projectFacebook: 'ButterProjectOrg',
     projectGooglePlus: 'ButterProject',
-    projectBlog: 'https://butterproject.github.io/butter/blog',
-    projectForum: 'https://butterproject.github.io/butter/forum',
+    projectBlog: 'http://blog.butterproject.org/',
+    projectForum: 'http://discuss.butterproject.org/',
 
     statusUrl: 'https://status.butterproject.org',
-    changelogUrl: 'https://butterproject.github.io/butter/',
+    changelogUrl: 'https://github.com/butterproject/butter-desktop/commits/master',
     issuesUrl: 'https://github.com/butterproject/butter-desktop/issues',
     sourceUrl: 'https://github.com/butterproject/butter-desktop/',
     commitUrl: 'https://github.com/butterproject/butter-desktop/commit'
@@ -109,7 +109,7 @@ Settings.updateEndpoint = {
         url: 'https://butterproject.org/',
         fingerprint: '',
     }, {
-        url: 'https://butterproject.github.com/butter/updates',
+        url: 'https://butterproject.github.io/',
         fingerprint: ''
     }]
 };

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -10,9 +10,9 @@ var Settings = {
 
     statusUrl: 'https://status.butterproject.org',
     changelogUrl: 'https://butterproject.github.io/butter/',
-    issuesUrl: 'https://github.com/butterproject/butter/issues',
-    sourceUrl: 'https://github.com/butterproject/butter/',
-    commitUrl: 'https://github.com/butterproject/butter/commit'
+    issuesUrl: 'https://github.com/butterproject/butter-desktop/issues',
+    sourceUrl: 'https://github.com/butterproject/butter-desktop/',
+    commitUrl: 'https://github.com/butterproject/butter-desktop/commit'
 };
 
 // User interface


### PR DESCRIPTION
- Changed all occurrences of the old repo name (butter) to the new repo name (butter-desktop)
- Changed all occurrences of the old site (butterproject.github.io) to butterproject.org
- Added dependency status badges