### PR TITLE
NSIS script improvements

### DIFF
--- a/dist/windows/installer_makensis.nsi
+++ b/dist/windows/installer_makensis.nsi
@@ -1,6 +1,7 @@
 ﻿;Butter
 ;Installer Source for NSIS 3.0 or higher
 
+
 ;Enable Unicode encoding
 Unicode True
 
@@ -19,7 +20,9 @@ Unicode True
 ; ------------------- ;
 !searchparse /file "..\..\Gruntfile.js" "version: '" APP_NW "',"
 
-;Parse package.json
+; ------------------- ;
+; Parse package.json  ;
+; ------------------- ;
 !searchparse /file "..\..\package.json" '"name": "' APP_NAME '",'
 !searchreplace APP_NAME "${APP_NAME}" "-" " "
 !searchparse /file "..\..\package.json" '"version": "' PT_VERSION '",'
@@ -142,7 +145,7 @@ RequestExecutionLevel user
 !insertmacro MUI_LANGUAGE "Welsh"
 
 ; ------------------- ;
-;    Localization     ;
+;    Localisation     ;
 ; ------------------- ;
 LangString removeDataFolder ${LANG_ENGLISH} "Remove all databases and configuration files?"
 LangString removeDataFolder ${LANG_Afrikaans} "Alle databasisse en opset lêers verwyder?" 
@@ -354,7 +357,7 @@ Section
 
     ;Set output path to InstallDir
     SetOutPath "\\?\$INSTDIR"
-    
+
     ;Add the files
     File "..\..\cache\${APP_NW}\${ARCH}\*.dll"
     File "..\..\cache\${APP_NW}\${ARCH}\nw.exe"
@@ -381,15 +384,21 @@ Section
     File /r /x ".*" /x "test*" /x "example*" "..\..\src\app\vendor"
     File "..\..\src\app\index.html"
     File "..\..\src\app\*.js"
-    File /oname=License.txt "..\..\dist\windows\LICENSE.txt"
+    File /oname=License.txt "LICENSE.txt"
 
+    ;Set output path to InstallDir
     SetOutPath "\\?\$INSTDIR"
+
+    ;Add the files
     File "..\..\package.json"
     File "..\..\build\${APP_NAME}\${ARCH}\${APP_LAUNCHER}"
     File "..\..\CHANGELOG.md"
-    File /NONFATAL "..\..\.git.json"
+    File /nonfatal "..\..\.git.json"
 
+    ;Set output path to InstallDir
     SetOutPath "\\?\$INSTDIR\node_modules"
+
+    ;Add the files
     !ifdef UNIX_PATHS
         File /r /x "*grunt*" /x "stylus" /x "nw-gyp" /x "bower" /x ".bin" /x "bin" /x "test"  /x "test*" /x "example*" /x ".*" /x "*.md" /x "*.gz" /x "benchmark*" /x "*.markdown" "../../node_modules/*.*"
     !else

--- a/dist/windows/installer_makensis.nsi
+++ b/dist/windows/installer_makensis.nsi
@@ -354,28 +354,13 @@ Section
 
     ;Set output path to InstallDir
     SetOutPath "\\?\$INSTDIR"
-
-    ;Check to see if this nw uses datfiles
-    !define DATPATH "..\..\cache\${APP_NW}\${ARCH}\"
-
-    !ifdef DATPATH
-        !if /FILEEXISTS "${DATPATH}icudtl.dat"
-            ;File exists!
-            !define DATFILES
-        !else
-            ;File does NOT exist!
-        !endif
-    !endif
     
     ;Add the files
     File "..\..\cache\${APP_NW}\${ARCH}\*.dll"
     File "..\..\cache\${APP_NW}\${ARCH}\nw.exe"
     File "..\..\cache\${APP_NW}\${ARCH}\nw.pak"
     File /r "..\..\cache\${APP_NW}\${ARCH}\locales"
-
-    !ifdef DATFILES
-        File "${DATPATH}*.dat"
-    !endif
+    File /nonfatal "..\..\cache\${APP_NW}\${ARCH}\*.dat"
 SectionEnd
 
 ; ------------------- ;

--- a/dist/windows/installer_makensis.nsi
+++ b/dist/windows/installer_makensis.nsi
@@ -8,43 +8,24 @@ Unicode True
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
 
-;Check file paths
-!if /FILEEXISTS "..\..\package.json"
-    ;File exists!
-    !define WIN_PATHS
-!else
-    ;File does NOT exist!
+;Detect paths style
+!if /FILEEXISTS "../../package.json"
+    ;Unix-style paths detected!
+    !define UNIX_PATHS
 !endif
 
 ; ------------------- ;
 ;  Parse Gruntfile.js ;
 ; ------------------- ;
-!ifdef WIN_PATHS
-    !searchparse /file "..\..\Gruntfile.js" "version: '" APP_NW "',"
-!else
-    !searchparse /file "../../Gruntfile.js" "version: '" APP_NW "',"
-!endif
+!searchparse /file "..\..\Gruntfile.js" "version: '" APP_NW "',"
 
 ;Parse package.json
-!ifdef WIN_PATHS
-    !searchparse /file "..\..\package.json" '"name": "' APP_NAME '",'
-!else
-    !searchparse /file "../../package.json" '"name": "' APP_NAME '",'
-!endif
+!searchparse /file "..\..\package.json" '"name": "' APP_NAME '",'
 !searchreplace APP_NAME "${APP_NAME}" "-" " "
-!ifdef WIN_PATHS
-    !searchparse /file "..\..\package.json" '"version": "' PT_VERSION '",'
-!else
-    !searchparse /file "../../package.json" '"version": "' PT_VERSION '",'
-!endif
+!searchparse /file "..\..\package.json" '"version": "' PT_VERSION '",'
 !searchreplace PT_VERSION_CLEAN "${PT_VERSION}" "-" ".0"
-!ifdef WIN_PATHS
-    !searchparse /file "..\..\package.json" '"homepage": "' APP_URL '",'
-    !searchparse /file "..\..\package.json" '"name": "' DATA_FOLDER '",'
-!else
-    !searchparse /file "../../package.json" '"homepage": "' APP_URL '",'
-    !searchparse /file "../../package.json" '"name": "' DATA_FOLDER '",'
-!endif
+!searchparse /file "..\..\package.json" '"homepage": "' APP_URL '",'
+!searchparse /file "..\..\package.json" '"name": "' DATA_FOLDER '",'
 
 ; ------------------- ;
 ;      Settings       ;
@@ -78,15 +59,9 @@ RequestExecutionLevel user
 ;     UI Settings     ;
 ; ------------------- ;
 ;Define UI settings
-!ifdef WIN_PATHS
-    !define MUI_UI_HEADERIMAGE_RIGHT "..\..\src\app\images\icon.png"
-    !define MUI_ICON "..\..\src\app\images\butter.ico"
-    !define MUI_UNICON "..\..\src\app\images\butter_uninstall.ico"
-!else
-    !define MUI_UI_HEADERIMAGE_RIGHT "../../src/app/images/icon.png"
-    !define MUI_ICON "../../src/app/images/butter.ico"
-    !define MUI_UNICON "../../src/app/images/butter_uninstall.ico"
-!endif
+!define MUI_UI_HEADERIMAGE_RIGHT "..\..\src\app\images\icon.png"
+!define MUI_ICON "..\..\src\app\images\butter.ico"
+!define MUI_UNICON "..\..\src\app\images\butter_uninstall.ico"
 !define MUI_WELCOMEFINISHPAGE_BITMAP "installer-image.bmp"
 !define MUI_UNWELCOMEFINISHPAGE_BITMAP "uninstaller-image.bmp"
 !define MUI_ABORTWARNING
@@ -381,11 +356,7 @@ Section
     SetOutPath "\\?\$INSTDIR"
 
     ;Check to see if this nw uses datfiles
-    !ifdef WIN_PATHS
-        !define DATPATH "..\..\cache\${APP_NW}\${ARCH}\"
-    !else
-        !define DATPATH "../../cache/${APP_NW}/${ARCH}/"
-    !endif
+    !define DATPATH "..\..\cache\${APP_NW}\${ARCH}\"
 
     !ifdef DATPATH
         !if /FILEEXISTS "${DATPATH}icudtl.dat"
@@ -397,17 +368,10 @@ Section
     !endif
     
     ;Add the files
-    !ifdef WIN_PATHS
-        File "..\..\cache\${APP_NW}\${ARCH}\*.dll"
-        File "..\..\cache\${APP_NW}\${ARCH}\nw.exe"
-        File "..\..\cache\${APP_NW}\${ARCH}\nw.pak"
-        File /r "..\..\cache\${APP_NW}\${ARCH}\locales"
-    !else
-        File "../../cache/${APP_NW}/${ARCH}/*.dll"
-        File "../../cache/${APP_NW}/${ARCH}/nw.exe"
-        File "../../cache/${APP_NW}/${ARCH}/nw.pak"
-        File /r "../../cache/${APP_NW}/${ARCH}/locales"
-    !endif
+    File "..\..\cache\${APP_NW}\${ARCH}\*.dll"
+    File "..\..\cache\${APP_NW}\${ARCH}\nw.exe"
+    File "..\..\cache\${APP_NW}\${ARCH}\nw.pak"
+    File /r "..\..\cache\${APP_NW}\${ARCH}\locales"
 
     !ifdef DATFILES
         File "${DATPATH}*.dat"
@@ -422,51 +386,30 @@ Section
     SetOutPath "\\?\$INSTDIR\src\app"
 
     ;Add the files
-    !ifdef WIN_PATHS
-        File /r "..\..\src\app\css"
-        File /r "..\..\src\app\fonts"
-        File /r "..\..\src\app\images"
-        File /r "..\..\src\app\language"
-        File /r "..\..\src\app\lib"
-        File /r "..\..\src\app\templates"
-        File /r "..\..\src/app\themes"
-        File /r /x ".*" /x "test*" /x "example*" "..\..\src\app\vendor"
-        File "..\..\src\app\index.html"
-        File "..\..\src\app\*.js"
-        File /oname=License.txt "..\..\dist\windows\LICENSE.txt"
-    !else
-        File /r "../../src/app/css"
-        File /r "../../src/app/fonts"
-        File /r "../../src/app/images"
-        File /r "../../src/app/language"
-        File /r "../../src/app/lib"
-        File /r "../../src/app/templates"
-        File /r "../../src/app/themes"
-        File /r /x ".*" /x "test*" /x "example*" "../../src/app/vendor"
-        File "../../src/app/index.html"
-        File "../../src/app/*.js"
-        File /oname=License.txt "../../dist/windows/LICENSE.txt"
-    !endif
+    File /r "..\..\src\app\css"
+    File /r "..\..\src\app\fonts"
+    File /r "..\..\src\app\images"
+    File /r "..\..\src\app\language"
+    File /r "..\..\src\app\lib"
+    File /r "..\..\src\app\templates"
+    File /r "..\..\src/app\themes"
+    File /r /x ".*" /x "test*" /x "example*" "..\..\src\app\vendor"
+    File "..\..\src\app\index.html"
+    File "..\..\src\app\*.js"
+    File /oname=License.txt "..\..\dist\windows\LICENSE.txt"
 
     SetOutPath "\\?\$INSTDIR"
-    !ifdef WIN_PATHS
-        File "..\..\package.json"
-        File "..\..\build\${APP_NAME}\${ARCH}\${APP_LAUNCHER}"
-        File "..\..\CHANGELOG.md"
-        File /NONFATAL "..\..\.git.json"
-    !else
-        File "../../package.json"
-        File "../../build/${APP_NAME}/${ARCH}/${APP_LAUNCHER}"
-        File "../../CHANGELOG.md"
-        File /NONFATAL "../../.git.json"
-    !endif
+    File "..\..\package.json"
+    File "..\..\build\${APP_NAME}\${ARCH}\${APP_LAUNCHER}"
+    File "..\..\CHANGELOG.md"
+    File /NONFATAL "..\..\.git.json"
 
     SetOutPath "\\?\$INSTDIR\node_modules"
-    !ifdef WIN_PATHS
+    !ifdef UNIX_PATHS
+        File /r /x "*grunt*" /x "stylus" /x "nw-gyp" /x "bower" /x ".bin" /x "bin" /x "test"  /x "test*" /x "example*" /x ".*" /x "*.md" /x "*.gz" /x "benchmark*" /x "*.markdown" "../../node_modules/*.*"
+    !else
         !searchreplace node_modules ${__FILEDIR__} "\dist\windows" "\node_modules"
         File /r /x "*grunt*" /x "stylus" /x "nw-gyp" /x "bower" /x ".bin" /x "bin" /x "test"  /x "test*" /x "example*" /x ".*" /x "*.md" /x "*.gz" /x "benchmark*" /x "*.markdown" "\\?\${node_modules}\*.*"
-    !else
-        File /r /x "*grunt*" /x "stylus" /x "nw-gyp" /x "bower" /x ".bin" /x "bin" /x "test"  /x "test*" /x "example*" /x ".*" /x "*.md" /x "*.gz" /x "benchmark*" /x "*.markdown" "../../node_modules/*.*"
     !endif
 
     ;Create uninstaller


### PR DESCRIPTION
- WIN_PATHS logic was previously added (https://github.com/butterproject/butter-desktop/commit/2efc5c2664bd3e3cb9a2ce53d4944f2ed567d708) to allow cross-platform compilation of this script, the downside is that we needed to include all input paths twice, one for Windows and another for Unix-like systems. Since the Unix/Linux version of makensis (v3) supports both back slashes and forward slashes in input paths, it is moot to keep both; with a single exception which is a specific case where a Windows-only workaround for long paths does not work in Unix/Linux environments and as such it is the only exception to be retained;
- The NSIS compilation process doesn't need to detect the existence of NW .dat files to know whether to add them or not, it suffices to assume they exist and use the "nonfatal" argument, if they exist they get added, if they don't then the console just prints a warning and carries on with the compilation as usual;
- Minor changes, not that important, purely cosmetic;
- Updated the NSIS updater with the same changes applied to the installer
script.