### PR TITLE
Fix grunt platform/architecture detection

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ var parseBuildPlatforms = function (argumentPlatform) {
     // Do some scrubbing to make it easier to match in the regexes bellow
     inputPlatforms = inputPlatforms.replace("darwin", "mac");
     inputPlatforms = inputPlatforms.replace(/;ia|;x|;arm/, "");
-    if (process.arch === "x64") {
+    if (process.arch === "x64" && argumentPlatform === "") {
         inputPlatforms = inputPlatforms.replace("32", "64");
     }
 


### PR DESCRIPTION
- It wasn't possible to produce an x86 build from an x64 architecture system due to the incomplete logic.
This addition still defaults to x64 build when doing so from an x64 system, but also allows to produce an x86 build from an x64 architecture, if arguments are supplied.