### PR TITLE
Don't set unexisting file as executable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -310,11 +310,14 @@ module.exports = function (grunt) {
             setexecutable: {
                 command: function () {
                     if (host.linux || host.mac) {
-                        return [
-                            'pct_rel="build/' + projectName + '"',
-                            'chmod -R +x ${pct_rel}/osx*/' + projectName + '.app || : ',
-                            'chmod +x ${pct_rel}/linux*/' + projectName + ' || : '
-                        ].join(' && ');
+                        var cmds = ['pct_rel="build/' + projectName + '"'];
+                        if (buildPlatforms.mac32 || buildPlatforms.mac64) {
+                            cmds.push('chmod -R +x ${pct_rel}/osx*/' + projectName + '.app || : ');
+                        }
+                        if (buildPlatforms.linux32 || buildPlatforms.linux64) {
+                            cmds.push('chmod +x ${pct_rel}/linux*/' + projectName + ' || : ');
+                        }
+                        return cmds.join(' && ');
                     } else {
                         return 'echo ""'; // Not needed in Windows
                     }


### PR DESCRIPTION
Running 'grunt build' resulted in the following error on linux:
Running shell:setexecutable (shell) task
chmod: cannot access ‘build/Butter/osx*/Butter.app’: No such file or directory

This fixes the issue by only setting the existing file as executable
Fixes #169 