### PR TITLE
docs : Provide SO link for npm permission problem solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The [master](https://github.com/butterproject/butter-desktop) branch which conta
 
 If you encounter trouble with the above method, you can try:
 
-1. `npm install -g bower grunt-cli` (Linux: you may need to run with `sudo`)
+  1. `npm install -g bower grunt-cli` (Linux: [See this link for permission problems](http://stackoverflow.com/a/24404451/1329429))
 1. `cd desktop`
 1. `npm install`
 1. `bower install`


### PR DESCRIPTION
Some time ago I read somewhere it is bad to install/run `npm` with `sudo` ([a similar post](https://blog.explosionpills.com/dont-use-sudo-with-npm/) )  
I had the same problem and finally [a SO answer](http://stackoverflow.com/a/24404451/1329429) solved the problem completely(I am now using `nvm` and happy again)  

I replaced the suggestion to use npm with sudo with a reference to mentioned answer.

Thanks
