### PR TITLE
use file:// protocol on local video files (fix GET_ERR app://host)

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -466,7 +466,7 @@ var handleVideoFile = function (file) {
 
     // init our objects
     var playObj = {
-        src: path.join(file.path),
+        src: 'file://' + path.join(file.path),
         type: 'video/mp4'
     };
     var sub_data = {


### PR DESCRIPTION
Fix tested on linux and windows. Maybe worth checking on OSX if drag&drop video file directly into Butter still works (if the file plays).