### PR TITLE
fix #375

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,6 +124,7 @@ const nw = new nwBuilder({
     macIcns: './src/app/images/butter.icns',
     version: nwVersion,
     platforms: parsePlatforms(),
+    currentPlatform: parsePlatforms()[0],
     downloadUrl: 'https://raw.githubusercontent.com/butterproject/nwjs-prebuilt/master/'
 }).on('log', console.log);
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "gulp-load-plugins": "^1.2.0",
         "guppy-pre-commit": "^0.3.0",
         "nib": "^1.1.0",
-        "nw-builder": "^2.0.2",
+        "nw-builder": "butterproject/nw-builder#fix/310",
         "run-sequence": "^1.1.5",
         "stylus": "^0.54.2",
         "yargs": "^4.4.0"


### PR DESCRIPTION
replace nw-builder with a fork (PR waiting merge) to allow the use of a
custom 'currentPlatform' flag, allowing to run 32bits executable on 64bits
machines

todo: switch back to official if/when pr is merged