### PR TITLE
gulp run fixup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -133,7 +133,7 @@ const nw = new nwBuilder({
  *************/
 // start app in development
 gulp.task('run', () => {
-    return new Promise(function (resolve, reject) {
+    return new Promise((resolve, reject) => {
         let platform = parsePlatforms()[0],
             bin = path.join('cache', nwVersion, platform);        
 


### PR DESCRIPTION
use non-hardcoded spawn replacement for nw.run()
* conveniently allows restarting the app
* full error log
* report node logs to main console
* fixes #381
* fixes #375