### PR TITLE
Fixed TypeScript Error: handle.state is not a function.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ const nw = new nwBuilder({
     macIcns: './src/app/images/butter.icns',
     version: nwVersion,
     platforms: parsePlatforms(),
-    downloadUrl: 'https://raw.githubusercontent.com/butterproject/nwjs-prebuilt/master/'
+    //downloadUrl: 'https://raw.githubusercontent.com/butterproject/nwjs-prebuilt/master/'
 }).on('log', console.log);
 
 


### PR DESCRIPTION
Commented the donwloadURL line from gulpfile.js, which was causing the TypeScript Error introduced in Issue #418.
Now the application can be built successfully.