### PR TITLE
fix nw prebuit download url

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,7 @@ const nw = new nwBuilder({
     macIcns: './src/app/images/butter.icns',
     version: nwVersion,
     platforms: parsePlatforms(),
-    downloadUrl: 'https://raw.githubusercontent.com/butterproject/nwjs-prebuilt/master/'
+    downloadUrl: 'http://dl.nwjs.io/'
 }).on('log', console.log);
 
 


### PR DESCRIPTION
Problem: 400 when trying to download prebuilt nw from `https://raw.githubusercontent.com/butterproject/nwjs-prebuilt/master/`

Solution: change it to `http://dl.nwjs.io/`

I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)
