### PR TITLE
Choose default player on settings

### DIFF
--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -61,6 +61,11 @@
                 }
             });
 
+            var el = $('#chosenPlayer');
+            App.Device.Collection.forEach(function (device) {
+                el.append(new Option(device.get('name'), device.get('id'), false, App.settings['chosenPlayer'] === device.get('id') ? true : false));
+            });            
+
             Mousetrap.bind('backspace', function (e) {
                 App.vent.trigger('settings:close');
             });
@@ -256,6 +261,9 @@
             case 'opensubtitlesUsername':
             case 'opensubtitlesPassword':
                 return;
+            case 'chosenPlayer':
+                value = $('option:selected', field).val();
+                break;
             default:
                 win.warn('Setting not defined: ' + field.attr('name'));
             }

--- a/src/app/templates/settings-container.tpl
+++ b/src/app/templates/settings-container.tpl
@@ -287,6 +287,13 @@
     <section id="playback">
         <div class="title"><%= i18n.__("Playback") %></div>
         <div class="content">
+            <span>
+                <div class="dropdown chosen-player">
+                  <p><%= i18n.__("Video Player") %></p>
+                  <select name="chosenPlayer" id="chosenPlayer" style="width: 160px;"></select>
+                  <div class="dropdown-arrow"></div>
+                </div>
+            </span>
             <span class="advanced">
                 <input class="settings-checkbox" name="alwaysFullscreen" id="alwaysFullscreen" type="checkbox" <%=(Settings.alwaysFullscreen? "checked='checked'":"")%>>
                 <label class="settings-label" for="alwaysFullscreen"><%= i18n.__("Always start playing in fullscreen") %></label>


### PR DESCRIPTION
Changes proposed in this pull request:
- Hability to choose a default player ins settings view.

I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)
Hability to choose a default player ins settings view.
