### PR TITLE
Default background on loading view

### DIFF
--- a/src/app/lib/models/generic_collection.js
+++ b/src/app/lib/models/generic_collection.js
@@ -80,8 +80,14 @@
                                 }
                             }
 
-                            if (info.images.fanart) {
+                            if (info.images.full) {
                                 movie.backdrop = info.images.full;
+                            } else if (info.images.fanart && info.images.fanart.full) {
+                                movie.backdrop = info.images.fanart.full;
+                            } else if (movie.cover) {
+                                movie.backdrop = movie.cover;
+                            } else {
+                                movie.backdrop = 'images/bg-header.jpg';
                             }
                         } else {
                             win.warn('Unable to find %s (%s) on Trakt.tv', id, movie.title);

--- a/src/app/styl/views/loading.styl
+++ b/src/app/styl/views/loading.styl
@@ -20,6 +20,7 @@
         background-position-x 50%
         background-position-y 0px
         background-size cover
+        -webkit-filter: blur(15px) brightness(0.7)
 
     .loading-background-overlay
         width 100%
@@ -112,7 +113,7 @@
             background-color $ButtonBg
             -webkit-backface-visibility hidden
             transition all .5s
-            
+
             &:hover
                 background: $ButtonBgHover
                 text-decoration: none

--- a/src/app/styl/views/movie_detail.styl
+++ b/src/app/styl/views/movie_detail.styl
@@ -24,6 +24,7 @@
         opacity: 0
         background-position-x 50%
         background-position-y -33px
+        -webkit-filter: blur(15px) brightness(0.7)
         background-repeat: no-repeat
         background-size: cover
         &.fadein
@@ -70,7 +71,7 @@
                 font-smoothing: antialiased
 
             .metadatas
-                top: 15px     
+                top: 15px
                 height: 20px
                 position: relative
 
@@ -234,7 +235,7 @@
                     opacity: 1
                     transition: opacity 0.5s
 
-                &:after 
+                &:after
                     content: "\f004"
                     font-family: FontAwesome
                     position: absolute
@@ -305,7 +306,7 @@
                     opacity: 1
                     transition: opacity 0.5s
 
-                &:after 
+                &:after
                     content: "\f00c"
                     font-family: FontAwesome
                     position: absolute
@@ -399,10 +400,10 @@
                 display: none
                 height: auto
                 background: rgba(20, 24, 26, 0.6)
-                
+
                 .flag
                     height: 16px;
-                
+
 
             .flag
                 margin: 3px
@@ -530,7 +531,7 @@
                 .startStreaming
                     margin-left: 12px
                     margin-right: 12px
-                    
+
                     &:after
                         content: ''
                         width: 70%

--- a/src/app/templates/loading.tpl
+++ b/src/app/templates/loading.tpl
@@ -17,7 +17,6 @@
             <!-- downloading info -->
             <div class="loading-info">
                 <span class="buffer_percent"></span><br><br>
-                
                 <span class="loading-info-text"><%= i18n.__("Download") %>:&nbsp;</span>
                 <span class="download_speed value"><%= Common.fileSize(0) %>/s</span><br>
                 <span class="loading-info-text"><%= i18n.__("Upload") %>:&nbsp;</span>


### PR DESCRIPTION
Changes proposed in this pull request:
- If no background image or image could not be loaded when loading a movie or show we set the default background image on loading view.

I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)
If no background image or image could not be loaded we set the default background image on loading view.