### PR TITLE
uglify js/css files (saves 11Mb)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -443,15 +443,16 @@ gulp.task('uglify', () => {
                         let file = path.join(p,f);
                         switch (path.extname(f)) {
                             case '.js':
+                                var minified;
                                 try {
-                                    var minified = uglify.minify(file, {
+                                    minified = uglify.minify(file, {
                                         mangle: false
                                     });
                                 } catch (e) {
                                     looping = Date.now();
                                     return cb();
                                 }
-                                if (minified.code) {
+                                if (minified && minified.code) {
                                     fs.writeFile(file, minified.code, function (err) {
                                         if (!err) {
                                             console.log('Minified:', file);
@@ -471,20 +472,26 @@ gulp.task('uglify', () => {
                                         return cb();
                                     }
 
+                                    var minified;
                                     try {
-                                        var minified = sqwish.minify(content.toString());
+                                        minified = sqwish.minify(content.toString());
                                     } catch (e) {
                                         looping = Date.now();
                                         return cb();
                                     }
 
-                                    fs.writeFile(file, minified, function (err) {
-                                        if (!err) {
-                                            console.log('Minified:', file);
-                                        }
+                                    if (minified) {
+                                        fs.writeFile(file, minified, function (err) {
+                                            if (!err) {
+                                                console.log('Minified:', file);
+                                            }
+                                            looping = Date.now();
+                                            return cb();
+                                        });
+                                    } else {
                                         looping = Date.now();
                                         return cb();
-                                    });
+                                    }
                                 });
                                 break;
                             default:

--- a/package.json
+++ b/package.json
@@ -97,7 +97,9 @@
         "nib": "^1.1.0",
         "nw-builder": "^3.1.2",
         "run-sequence": "^1.1.5",
+        "sqwish": "^0.2.2",
         "stylus": "^0.54.2",
+        "uglify-js": "^2.7.4",
         "yargs": "^6.3.0"
     }
 }

--- a/src/app/lib/subtitle/generic.js
+++ b/src/app/lib/subtitle/generic.js
@@ -73,7 +73,7 @@
                             reject(e);
                         }
                     } else if (fgz) {
-                        require('zlib').unzip(fs.readFileSync(fpath+ext), (error, buffer) => {
+                        require('zlib').unzip(fs.readFileSync(fpath+ext), function (error, buffer) {
                             if (error) {
                                 reject(error);
                             } else {


### PR DESCRIPTION
- gulp uglify task, for js/css files. 
- saves 11Mb of space (2.1Mb of app files, 8.9Mb of node_modules)
- not used by default, has to be called specifically
- incompatible with arrow functions, for some reason