### PR TITLE
Vkj/dbclick player

### DIFF
--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -414,7 +414,7 @@
             this.player = this.video.player();
 
             // Better handle click/dblclick events for play/pause/fs
-            this.player.click = {count: 0, dblclick: false}; // init conf
+            this.player.click = 0;
             this.player.tech.off('mousedown'); // stop listening to default ev
             this.player.tech.on('mouseup', this.onClick.bind(this));
             $('#video_player').dblclick(this.onDbClick.bind(this));
@@ -476,25 +476,23 @@
         },
 
         onClick: function (e) {
-            this.player.click.count++;
-
-            if (this.player.click.count === 1) { // it's the first time we click
-                setTimeout(function () { // wait for double click
-                    if (!this.player.click.dblclick) { // if we didn't catch dbclick
-                        $('.vjs-play-control').click();
-                    }
-                    this.player.click.count = 0;
-                    this.player.click.dblclick = false;
-                }.bind(this), dblclick_delay);
-            } else { // we already clicked, reset
-                this.player.click.count = 0;
-                this.player.click.dblclick = false;
+            if (this.player.click) {
+                return this.player.click = 0;
             }
+
+            this.player.click++;
+
+            return setTimeout(function () { // wait for double click
+                if (this.player.click) { // if we didn't catch dbclick
+                    $('.vjs-play-control').click();
+                    this.player.click = 0;
+                }
+            }.bind(this), dblclick_delay);
         },
 
-        onDbClick: function (e) {
-            this.player.click.dblclick = true;
+        onDbClick: function(e) {
             this.toggleFullscreen();
+            this.player.click = 0;
         },
 
         sendToTrakt: function (method) {

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -265,25 +265,17 @@
         },
 
         showPlayIcon: function () {
-            if (this.ui.play.is(':visible')) {
+            var wasPlaying = this.player.paused();
+            var showIcon = wasPlaying ? 'pause' : 'play';
+            var hideIcon = wasPlaying ? 'play' : 'pause';
+
+            if (this.ui[showIcon].is(':visible')) {
                 return;
             }
-            this.ui.pause.hide().dequeue();
-            this.ui.play.appendTo('div#video_player');
-            this.ui.play.show().delay(1500).queue(function () {
-                this.ui.play.hide().dequeue();
-            }.bind(this));
-        },
-
-        showPauseIcon: function () {
-            if (this.ui.pause.is(':visible')) {
-                return;
-            }
-
-            this.ui.play.hide().dequeue();
-            this.ui.pause.appendTo('div#video_player');
-            this.ui.pause.show().delay(1500).queue(function () {
-                this.ui.pause.hide().dequeue();
+            this.ui[hideIcon].hide().dequeue();
+            this.ui[showIcon].appendTo('div#video_player');
+            this.ui[showIcon].show().delay(1500).queue(function () {
+                this.ui[showIcon].hide().dequeue();
             }.bind(this));
         },
 
@@ -318,7 +310,7 @@
                 this.wasSeek = true;
             } else {
                 this.wasSeek = false;
-                this.showPauseIcon();
+                this.showPlayIcon();
                 App.vent.trigger('player:pause');
                 this.sendToTrakt('pause');
             }

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -1,6 +1,9 @@
 (function (App) {
     'use strict';
 
+    var dblclick_timeout = 300,
+        notif_displaytime = 3000;
+
     var Player = Backbone.Marionette.ItemView.extend({
         template: '#player-tpl',
         className: 'player',
@@ -484,7 +487,7 @@
                     }
                     this.player.click.count = 0;
                     this.player.click.dblclick = false;
-                }.bind(this), 300);
+                }.bind(this), dblclick_timeout);
             } else { // we already clicked, reset
                 this.player.click.count = 0;
                 this.player.click.dblclick = false;
@@ -939,14 +942,14 @@
                     $('.vjs-overlay').fadeOut('normal', function () {
                         $(this).remove();
                     });
-                }, 3000));
+                }, notif_displaytime));
             } else {
                 $(this.player.el()).append('<div class =\'vjs-overlay vjs-overlay-top-left\'>' + message + '</div>');
                 $.data(this, 'overlayTimer', setTimeout(function () {
                     $('.vjs-overlay').fadeOut('normal', function () {
                         $(this).remove();
                     });
-                }, 3000));
+                }, notif_displaytime));
             }
         },
 


### PR DESCRIPTION
- on click, wait to see if a doubleclick event passes
- if a dblclick is detected, ignore initial click // else proceed with click
- allows to not spam pause/play on doubleclick
- move ui.{play,pause} to their own function

Note: using `$('#video_player').dblclick` over `this.player.tech.dblclick` because we can then bypass the mouse being hidden (and tech is hidden too) when fullscreen