### PR TITLE
Xaiki/kill subtitles in generic

### DIFF
--- a/src/app/lib/models/generic_collection.js
+++ b/src/app/lib/models/generic_collection.js
@@ -48,7 +48,7 @@
                         return;
                     }
 
-                    movie.provider = torrentProvider.name;
+                    movie.providers = {torrent: torrentProvider};
 
                     if (metadatas.length && id) {
                         var info = _.findWhere(metadatas, {

--- a/src/app/lib/models/generic_collection.js
+++ b/src/app/lib/models/generic_collection.js
@@ -1,18 +1,13 @@
 (function (App) {
     'use strict';
 
-    var getDataFromProvider = function (torrentProvider, subtitle, metadata, self) {
+    var getDataFromProvider = function (torrentProvider, metadata, self) {
         var deferred = Q.defer();
 
         var torrentsPromise = torrentProvider.fetch(self.filter);
         var idsPromise = torrentsPromise.then(_.bind(torrentProvider.extractIds, torrentProvider));
         var promises = [
             torrentsPromise,
-
-            subtitle ? idsPromise.then(_.bind(subtitle.fetch, subtitle)).catch(function (err) {
-                console.error('Cannot fetch subtitles (%s):', torrentProvider.name, err);
-                return false;
-            }) : false,
 
             metadata ? idsPromise.then(function (ids) {
                 return Q.allSettled(_.map(ids, function (id) {
@@ -25,7 +20,7 @@
         ];
 
         Q.all(promises)
-            .spread(function (torrents, subtitles, metadatas) {
+            .spread(function (torrents, metadatas) {
 
                 // If a new request was started...
                 metadatas = _.map(metadatas, function (m) {
@@ -54,10 +49,6 @@
                     }
 
                     movie.provider = torrentProvider.name;
-
-                    if (subtitles) {
-                        movie.subtitle = subtitles[id];
-                    }
 
                     if (metadatas.length && id) {
                         var info = _.findWhere(metadatas, {
@@ -121,7 +112,6 @@
                 this.state = 'loading';
                 self.trigger('loading', self);
 
-                var subtitle = this.providers.subtitle;
                 var metadata = this.providers.metadata;
                 var torrents = this.providers.torrents;
 
@@ -135,7 +125,7 @@
                  */
 
                 var torrentPromises = _.map(torrents, function (torrentProvider) {
-                    return getDataFromProvider(torrentProvider, subtitle, metadata, self)
+                    return getDataFromProvider(torrentProvider, metadata, self)
                         .then(function (torrents) {
                             self.add(torrents.results);
                             self.hasMore = true;

--- a/src/app/lib/models/movie.js
+++ b/src/app/lib/models/movie.js
@@ -3,13 +3,21 @@
 
     var Movie = Backbone.Model.extend({
         events: {
-            'change:torrents': 'updateHealth',
+            'change:torrents': 'updateHealth'
         },
 
         idAttribute: 'imdb_id',
 
-        initialize: function () {
+        initialize: function (attrs) {
+            this.set('providers', Object.assign(attrs.providers,
+                                                this.getProviders()));
             this.updateHealth();
+        },
+
+        getProviders: function() {
+            return {
+                subtitle: App.Config.getProviderForType('subtitle')
+            };
         },
 
         updateHealth: function () {

--- a/src/app/lib/models/movie_collection.js
+++ b/src/app/lib/models/movie_collection.js
@@ -8,8 +8,7 @@
         getProviders: function () {
             return {
                 torrents: App.Config.getProviderForType('movie'),
-                metadata: App.Config.getProviderForType('metadata'),
-                subtitle: App.Config.getProviderForType('subtitle')
+                metadata: App.Config.getProviderForType('metadata')
             };
         }
     });

--- a/src/app/lib/models/show.js
+++ b/src/app/lib/models/show.js
@@ -3,6 +3,11 @@
 
     var Show = App.Model.Movie.extend({
         idAttribute: 'tvdb_id',
+
+        getProviders: function() {
+            return {};
+        },
+
         updateHealth: function () {
             var torrents = this.get('torrents');
 

--- a/src/app/lib/providers/opensubtitles.js
+++ b/src/app/lib/providers/opensubtitles.js
@@ -29,11 +29,15 @@
         for (var lang in data) {
             data[lang] = data[lang].url;
         }
-        return Common.sanitize(data);
+        return {subtitle: Common.sanitize(data)};
     };
 
-    OpenSubtitles.prototype.fetch = function (queryParams) {
-        queryParams.extensions = ['srt'];
+    OpenSubtitles.prototype.detail = function (id, attrs) {
+        var queryParams = {
+            imdbid: id,
+            extensions: ['srt']
+        };
+
         return openSRT.search(queryParams)
             .then(formatForButter);
     };

--- a/src/app/lib/providers/opensubtitles.js
+++ b/src/app/lib/providers/opensubtitles.js
@@ -29,17 +29,24 @@
         for (var lang in data) {
             data[lang] = data[lang].url;
         }
-        return {subtitle: Common.sanitize(data)};
+        return Common.sanitize(data);
     };
 
-    OpenSubtitles.prototype.detail = function (id, attrs) {
-        var queryParams = {
-            imdbid: id,
-            extensions: ['srt']
-        };
+    OpenSubtitles.prototype.fetch = function (queryParams) {
+        queryParams.extensions = ['srt'];
 
         return openSRT.search(queryParams)
             .then(formatForButter);
+    };
+
+    OpenSubtitles.prototype.detail = function (id, attrs) {
+        return this.fetch({
+            imdbid: id
+        }).then(function (data) {
+            return {
+                subtitle: data
+            };
+        });
     };
 
     OpenSubtitles.prototype.upload = function (queryParams) {

--- a/src/app/lib/streamer.js
+++ b/src/app/lib/streamer.js
@@ -436,9 +436,15 @@
             if (this.stopped) {
                 return;
             }
+
             // set default subtitle language (passed by a view or settings)
             var defaultSubtitle = this.torrentModel.get('defaultSubtitle') || Settings.subtitle_language;
-            this.torrentModel.set('defaultSubtitle', defaultSubtitle);        
+            this.torrentModel.set('defaultSubtitle', defaultSubtitle);   
+
+            // we already have subtitles
+            if (this.torrentModel.get('subtitle')) {
+                return this.subtitleReady = true;
+            }
 
             var subtitleProvider = App.Config.getProviderForType('subtitle');
 

--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -1,8 +1,6 @@
 (function (App) {
     'use strict';
 
-    var Q = require('q');
-
     var prevX = 0;
     var prevY = 0;
 
@@ -181,7 +179,7 @@
             // the models that already got fetched not too long ago, but we
             // actually use memoize in the providers code so it shouldn't be
             // necesary and we refresh the data anyway…
-            return Q.all(promises).then(function (results) {
+            return Promise.all(promises).then(function (results) {
                 $('.spinner').hide();
 
                 // XXX(xaiki): we merge all results into a single object,

--- a/src/app/lib/views/lang_dropdown.js
+++ b/src/app/lib/views/lang_dropdown.js
@@ -22,9 +22,7 @@
             if (this.hasNull) {
                 this.values = Object.assign({}, {none: undefined}, this.values);
                 this.model.set('values', this.values);
-            }
-
-            if (!this.selected && this.values) {
+            } else if (!this.selected && this.values) {
                 var values = Object.keys(this.values);
                 if (values.length) {
                     this.selected = values.pop();

--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -155,17 +155,21 @@
         },
 
         renderHealth: function () {
-            var torrent = this.model.get('torrents')[this.model.get('quality')];
-            var health = torrent.health.capitalize();
-            var ratio = torrent.peer > 0 ? torrent.seed / torrent.peer : +torrent.seed;
+            try {
+                var torrent = this.model.get('torrents')[this.model.get('quality')];
+                var health = torrent.health.capitalize();
+                var ratio = torrent.peer > 0 ? torrent.seed / torrent.peer : +torrent.seed;
 
-            $('.health-icon').tooltip({
-                    html: true
-                })
-                .removeClass('Bad Medium Good Excellent')
-                .addClass(health)
-                .attr('data-original-title', i18n.__('Health ' + health) + ' - ' + i18n.__('Ratio:') + ' ' + ratio.toFixed(2) + ' <br> ' + i18n.__('Seeds:') + ' ' + torrent.seed + ' - ' + i18n.__('Peers:') + ' ' + torrent.peer)
-                .tooltip('fixTitle');
+                $('.health-icon').tooltip({
+                        html: true
+                    })
+                    .removeClass('Bad Medium Good Excellent')
+                    .addClass(health)
+                    .attr('data-original-title', i18n.__('Health ' + health) + ' - ' + i18n.__('Ratio:') + ' ' + ratio.toFixed(2) + ' <br> ' + i18n.__('Seeds:') + ' ' + torrent.seed + ' - ' + i18n.__('Peers:') + ' ' + torrent.peer)
+                    .tooltip('fixTitle');
+            } catch(e) {
+                console.error('Cannot render health', e); //FIXME
+            }
         },
 
         openIMDb: function () {

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -69,7 +69,7 @@
         },
 
         loadComponents: function() {
-            var audios = this.model.get('audios');
+            var audios = this.model.get('langs');
             this.views.audio = new App.View.LangDropdown({
                 model: new App.Model.Lang({
                     type: 'audio',
@@ -153,7 +153,7 @@
         },
 
         switchAudio: function (lang) {
-            var audios = this.model.get('audios');
+            var audios = this.model.get('langs');
 
             if (audios === undefined || audios[lang] === undefined) {
                 lang = 'none';
@@ -161,22 +161,20 @@
 
             this.audio_selected = lang;
 
-            console.info('Audios: ' + this.audio_selected);
+            console.info('Audios: ' + lang);
         },
 
         startStreaming: function () {
-            var providerName = this.model.get('provider');
-            var provider = App.Providers.get(providerName);
+            var providers = this.model.get('providers');
             var quality = this.model.get('quality');
-            var lang = this.model.get('lang');
             var defaultTorrent = this.model.get('torrents')[quality];
 
             var filters =  {
                 quality: quality,
-                lang: lang
+                lang: this.audio_selected
             };
 
-            var torrent = provider
+            var torrent = providers.torrent
                 .resolveStream(defaultTorrent, filters, this.model.attributes);
 
             var torrentStart = new Backbone.Model({

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -185,7 +185,7 @@
                 defaultSubtitle: this.subtitle_selected,
                 title: this.model.get('title'),
                 quality: quality,
-                lang: lang,
+                lang: this.audio_selected,
                 type: 'movie',
                 device: App.Device.Collection.selected,
                 cover: this.model.get('cover')

--- a/src/app/lib/views/play_control.js
+++ b/src/app/lib/views/play_control.js
@@ -75,7 +75,7 @@
                     type: 'audio',
                     title: i18n.__('Audio Language'),
                     selected: this.model.get('defaultAudio'),
-                    values: audios || {en: undefined},
+                    values: audios || {en: undefined}
                 })
             });
             this.AudioDropdown.show (this.views.audio);
@@ -86,7 +86,7 @@
                     title: i18n.__('Subtitle'),
                     selected: this.model.get('defaultSubtitle'),
                     hasNull: true,
-                    values: this.model.get('subtitle'),
+                    values: this.model.get('subtitle')
                 })
             });
             this.SubDropdown.show (this.views.subs);

--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -885,6 +885,10 @@
         },
 
         adjustVolume: function (i) {
+            if (!this.player) {
+                return;
+            }
+
             var v = this.player.volume();
             this.player.volume(v + i);
             App.vent.trigger('volumechange');


### PR DESCRIPTION
implement subs fetching in item.js, it looks like we should move it to the view details class, but it sits there nicely anyway.

not sure we shouldn't remove this: 
```js
            // bookmarked movies are cached
            if (realtype === 'bookmarkedmovie') {
                return App.vent.trigger('movie:showDetail', this.model);
            }
```
as we'd miss subtitles for bookmarked movies but it's probably part of another bigger smarter PR.