### PR TITLE
Little UX improvment on quality selector in show detail page

### DIFF
--- a/src/app/styl/Official_-_Black_&_Yellow_theme.styl
+++ b/src/app/styl/Official_-_Black_&_Yellow_theme.styl
@@ -13,12 +13,12 @@
     $MainFontBold = 'Open Sans Bold'
     $AlternateFont = sans-serif
     $ButtonFont = 'Open Sans Semibold'
-    
+
 //Main app
     $BgColor1 = Black
     $BgColor2 = lighten(Black,5%)
 
-    $Text1 = #fff 
+    $Text1 = #fff
     $Text2 = #C9C9C9
     $Text3 = #939597
     $Text4 = #fff
@@ -29,18 +29,18 @@
 
     $SpinnerColor1 = YellowD2
     $SpinnerColor2 = YellowD
-    
+
     $ScrollBarBg = #30333c
     $ScrollBarThumb = YellowD2
     $ScrollBarThumbHover = YellowD
-    
+
 //Top Bar
-    $TitleBarBg = Black  
+    $TitleBarBg = Black
     $TitleBarText = #fff
     $FullScreenButton = #999
     $FullScreenButtonHover = YellowL
 
-    $FilterBarBg = Black  
+    $FilterBarBg = Black
     $FilterBarText = #e9e9e9
     $FilterBarTextHover = #fff
     $FilterBarActive = YellowL
@@ -56,22 +56,22 @@
     $FilterBarIcon = $Text1
     $FilterBarIconHover = YellowD
     $FilterBarIcon-PosterWidth = #bababa
-    
+
     $TopBarShadow = 0px 6px 8px -4px rgba(0, 0, 0, .9);
-    
+
 //Buttons
     $ButtonBg = YellowL
     $ButtonBgHover = YellowM
     $ButtonBgActive = YellowD
-    
+
     $ButtonBgDisabled = #737577
 
     $ButtonBgOk = #27AE60
     $ButtonBgWarning = #F15153
-    
+
     $ButtonText = #000
     $ButtonTextHover = #000
-    
+
     $ButtonRadius = 3px
 
 //Checkbox
@@ -83,13 +83,13 @@
     $PosterHoverBorder = $ButtonBgActive
     $PosterHoverOverlay = rgba(23, 24, 27, 0.6)
     $PosterShadow = 0px 0px 10px
-    
+
 //TV Series
     $ShowBgColor1 = $BgColor1
     $ShowBgColor2 = $BgColor2
 
     $EpisodeDetailsBg = $BgColor1
-    
+
     $ShowText1 = $Text1
     $ShowText2 = $Text2
 
@@ -104,7 +104,8 @@
     $ShowWatchedIcon_hover = rgba(#fff,0.4)
     $ShowWatchedIcon_true = #fff
 
-    $QualitySelector = $ButtonBg
+    $QualitySelectorBg = $ButtonBg
+    $QualitySelectorText = $ButtonText
 
 //File selector
     $FileSelectorText = #eee
@@ -114,10 +115,10 @@
 //Settings
     $SettingsCategoriesText = YellowD
     $SettingsSeparator = #333
-    
+
     $InputBoxBg = #232324
     $InputBoxText = $Text2
-    
+
     $SettingsText1 = $Text2
     $SettingsText2 = $Text3
 
@@ -144,11 +145,11 @@
     $WarningColor = #FFA500
     $PngLogo = brightness(1.0)
     $PngLogo_BgColo1 = brightness(1.0)
-    
+
 //Player
     $PlayerColor = YellowL
 
-    
+
 // OFFICIAL POPCORN-THEME: BLACK AND YELLOW - END
 
 @import 'views/app'

--- a/src/app/styl/Official_-_Dark_theme.styl
+++ b/src/app/styl/Official_-_Dark_theme.styl
@@ -4,7 +4,7 @@
     $Font = 'Open Sans'
     $MainFont = 'Open Sans Semibold'
     $MainFontBold = 'Open Sans Bold'
-    $AlternateFont = sans-serif    
+    $AlternateFont = sans-serif
     $ButtonFont = 'Open Sans Semibold'
 
 //Main app
@@ -52,7 +52,7 @@
 
     $TopBarShadow = 0px 6px 8px -4px rgba(0, 0, 0, .9);
 
-//$ButtonBg    
+//$ButtonBg
     $ButtonBg = #1f375f
     $ButtonBgHover = #225694
     $ButtonBgActive = #2468cc
@@ -97,7 +97,8 @@
     $ShowWatchedIcon_hover = rgba(#fff,0.4)
     $ShowWatchedIcon_true = #fff
 
-    $QualitySelector = rgba(43, 110, 210, 0.84)
+    $QualitySelectorBg = rgba(43, 110, 210, 0.84)
+    $QualitySelectorText = $ButtonText
 
 //File selector
     $FileSelectorText = #eee
@@ -113,7 +114,7 @@
 
     $SettingsText1 = #c3c5c7
     $SettingsText2 = #8a8b8e
-    
+
     $SettingsButtonText = #e3e5e7
     $SettingsButtonTextHover = #e3e5e7
 
@@ -137,11 +138,11 @@
     $PngLogo_BgColo1 = brightness(1.0)
     $WarningColor = #FFFF00
     $FavoriteColor = #df2d37
-    
-//Player 
+
+//Player
     $PlayerColor = #2d75df
 
 
 // OFFICIAL POPCORN-THEME: DARK - END
 
-@import 'views/app' 
+@import 'views/app'

--- a/src/app/styl/Official_-_FlaX_theme.styl
+++ b/src/app/styl/Official_-_FlaX_theme.styl
@@ -8,13 +8,13 @@
     DarkGrey = #555b65
     White = #f5f7fa
     Rose = #de5362
-    
+
 
 //Fonts
     $Font = 'Open Sans'
     $MainFont = 'Open Sans Semibold'
     $MainFontBold = 'Open Sans Bold'
-    $AlternateFont = sans-serif    
+    $AlternateFont = sans-serif
     $ButtonFont = 'Open Sans Semibold'
 
 //Main app
@@ -29,7 +29,7 @@
 
     $CloseButton = Rose
     $CloseButtonHover = darken(Rose,5)
-    
+
     $SpinnerColor1 = rgba(#fff,.2)
     $SpinnerColor2 = Rose
 
@@ -59,22 +59,22 @@
     $FilterBarIcon = lighten(LightGrey,10)
     $FilterBarIconHover = Rose
     $FilterBarIcon-PosterWidth = Rose
-    
+
     $TopBarShadow = 0px 6px 8px -4px rgba(0, 0, 0, 0)
 
 //Buttons
     $ButtonBg = Rose
     $ButtonBgHover = darken(Rose,4)
     $ButtonBgActive = darken(Rose,6)
-    
+
     $ButtonBgDisabled = #9ca5ab
 
     $ButtonBgOk = #27AE60
     $ButtonBgWarning = #cf283a
-    
+
     $ButtonText = #fff
     $ButtonTextHover = #fff
-    
+
     $ButtonRadius = 3px
 
 //Checkbox
@@ -92,22 +92,23 @@
     $ShowBgColor2 = lighten(DarkGreen,7)
 
     $EpisodeDetailsBg = lighten(DarkGreen,3)
-    
+
     $ShowText1 = White
     $ShowText2 = LightGrey
 
     $SaisonListText = White
     $EpisodeListText = White
-    
+
     $EpisodeSelectorBg = Rose
     $EpisodeSelectorHover = lighten($ShowBgColor2,6%)
     $EpisodeSelectorText = #fff
 
     $ShowWatchedIcon_false = rgba(White,0.3)
-    $ShowWatchedIcon_hover = rgba(White,0.6) 
+    $ShowWatchedIcon_hover = rgba(White,0.6)
     $ShowWatchedIcon_true = White
 
-    $QualitySelector = #df5362
+    $QualitySelectorBg = #df5362
+    $QualitySelectorText = $ButtonText
 
 //File selector
     $FileSelectorText = darken(White,5)
@@ -120,7 +121,7 @@
 
     $InputBoxBg = darken(Green,4)
     $InputBoxText = White
-    
+
     $SettingsText1 = darken(White,5)
     $SettingsText2 = rgba(darken(White,5),.7)
 
@@ -147,7 +148,7 @@
     $WarningColor = #FFFF00
     $PngLogo = brightness(1.0)
     $PngLogo_BgColo1 = brightness(1.0)
-    
+
 //Player
     $PlayerColor = Rose
 

--- a/src/app/styl/Official_-_Flat_UI_theme.styl
+++ b/src/app/styl/Official_-_Flat_UI_theme.styl
@@ -4,7 +4,7 @@
     $Font = 'Open Sans'
     $MainFont = 'Open Sans Semibold'
     $MainFontBold = 'Open Sans Bold'
-    $AlternateFont = sans-serif    
+    $AlternateFont = sans-serif
     $ButtonFont = 'Open Sans Semibold'
 
 //Main app
@@ -19,7 +19,7 @@
 
     $CloseButton = #e74c3c
     $CloseButtonHover = #c0392b
-    
+
     $SpinnerColor1 = rgba(#fff,.3)
     $SpinnerColor2 = #1ABC9C
 
@@ -49,22 +49,22 @@
     $FilterBarIcon = #fff
     $FilterBarIconHover = #1ABC9C
     $FilterBarIcon-PosterWidth = #bababa
-    
+
     $TopBarShadow = 0px 6px 8px -4px rgba(0, 0, 0, 0)
 
 //Buttons
     $ButtonBg = #1ABC9C
     $ButtonBgHover = #48c9b0
     $ButtonBgActive = #16a085
-    
+
     $ButtonBgDisabled = #d1d5d8
 
     $ButtonBgOk = #27AE60
     $ButtonBgWarning = #F15153
-    
+
     $ButtonText = #fff
     $ButtonTextHover = #fff
-    
+
     $ButtonRadius = 6px
 
 //Checkbox
@@ -82,22 +82,23 @@
     $ShowBgColor2 = #eff0f2
 
     $EpisodeDetailsBg = #fff
-    
+
     $ShowText1 = #34495e
     $ShowText2 = #7f8c8d
 
     $SaisonListText = #34495e
     $EpisodeListText = #34495e
-    
+
     $EpisodeSelectorBg = rgba(#003366,0.6)
     $EpisodeSelectorHover = darken($ShowBgColor2,10%)
     $EpisodeSelectorText = #fff
 
     $ShowWatchedIcon_false = rgba(#34495e,0.3)
-    $ShowWatchedIcon_hover = rgba(#34495e,0.6) 
+    $ShowWatchedIcon_hover = rgba(#34495e,0.6)
     $ShowWatchedIcon_true = #34495e
 
-    $QualitySelector = $ButtonBg
+    $QualitySelectorBg = $ButtonBg
+    $QualitySelectorText = $ButtonText
 
 //File selector
     $FileSelectorText = #34495e
@@ -110,7 +111,7 @@
 
     $InputBoxBg = #34495e
     $InputBoxText = #e1e4e7
-    
+
     $SettingsText1 = #34495e
     $SettingsText2 = #999
 
@@ -137,11 +138,11 @@
     $WarningColor = #000
     $PngLogo = brightness(1.0)
     $PngLogo_BgColo1 = brightness(0.4)
-    
+
 //Player
     $PlayerColor = #16a085
 
 
 // OFFICIAL POPCORN-THEME: FLAT - END
 
-@import 'views/app' 
+@import 'views/app'

--- a/src/app/styl/Official_-_High_Contrast_theme.styl
+++ b/src/app/styl/Official_-_High_Contrast_theme.styl
@@ -19,12 +19,12 @@
     $AlternateFont = sans-serif
     $ButtonFont = 'Open Sans Semibold'
 
-    
+
 //Main app
     $BgColor1 = Black
     $BgColor2 = lighten(Black,5%)
 
-    $Text1 = #fff 
+    $Text1 = #fff
     $Text2 = #000
     $Text3 = #fff
     $Text4 = #fff
@@ -44,18 +44,18 @@
 
     $SpinnerColor1 = PurpleD2
     $SpinnerColor2 = PurpleD
-    
+
     $ScrollBarBg = Black
     $ScrollBarThumb = PurpleD2
     $ScrollBarThumbHover = PurpleD
-    
+
 //Top Bar
-    $TitleBarBg = Black  
+    $TitleBarBg = Black
     $TitleBarText = #fff
     $FullScreenButton = #fff
     $FullScreenButtonHover = PurpleL
 
-    $FilterBarBg = Black  
+    $FilterBarBg = Black
     $FilterBarText = #fff
     $FilterBarTextHover = #fff
     $FilterBarActive = PurpleL
@@ -77,23 +77,23 @@
     $FilterBarIcon = #000
     $FilterBarIconHover = PurpleD
     $FilterBarIcon-PosterWidth = PurpleL
-//	Shadows and high contrast don't mix.    
+//	Shadows and high contrast don't mix.
 //  $TopBarShadow = 0px 6px 8px -4px rgba(0, 0, 0, .9);
-    
+
 //Buttons
     $ButtonBg = PurpleL
     $ButtonBgHover = PurpleM
     $ButtonBgActive = PurpleD
-    
+
     $ButtonBgDisabled = #ff0000 //who knows
 
     $ButtonBgOk = PurpleL
     $ButtonBgWarning = #ff0000
-    
+
     $ButtonText = #fff
     $ButtonTextHover = #fff
 
-    
+
     $ButtonRadius = 3px
 
 //Checkbox
@@ -106,14 +106,14 @@
     $PosterHoverBorder = $ButtonBgActive
 //  $PosterHoverOverlay = rgba(23, 24, 27, 0.6)
 //  $PosterShadow = 0px 0px 10px
-    
+
 //TV Series
     $ShowBgColor1 = $BgColor1
     $ShowBgColor2 = $BgColor2
 
     $EpisodeDetailsBg = $BgColor1
 
-    
+
     $ShowText1 = $Text1
     $ShowText2 = $Text2
 
@@ -128,7 +128,8 @@
     $ShowWatchedIcon_hover = rgba(#fff,0.4)
     $ShowWatchedIcon_true = #fff
 
-    $QualitySelector = $ButtonBg
+    $QualitySelectorBg = $ButtonBg
+    $QualitySelectorText = $ButtonText
 
 //File selector
     $FileSelectorText = #fff
@@ -141,10 +142,10 @@
 
 
 
-    
+
     $InputBoxBg = #fff
     $InputBoxText = $Text2
-    
+
     $SettingsText1 = $Text3
     $SettingsText2 = $Text3
 
@@ -173,12 +174,12 @@
     $WarningColor = #ffff00
 	$PngLogo = brightness(1.0)
     $PngLogo_BgColo1 = brightness(1.0)
-    
+
 //Player
     $PlayerColor = PurpleL
 
 
-    
+
 // OFFICIAL POPCORN-THEME: BLACK AND Purple - END
 
 @import 'views/app'

--- a/src/app/styl/Official_-_Light_theme.styl
+++ b/src/app/styl/Official_-_Light_theme.styl
@@ -23,13 +23,13 @@
     $Text3 = #515151
     $Text4 = #6b6b6b
     $TextError = #3d3d3d
-    
+
     $CloseButton = #b8b8b8
     $CloseButtonHover = #008f00
 
     $SpinnerColor1 = #00a300
     $SpinnerColor2 = rgba(70,186,78,0.9)
-    
+
     $ScrollBarBg = #d1d1d1
     $ScrollBarThumb =  GreenD
     $ScrollBarThumbHover = GreenL
@@ -44,7 +44,7 @@
     $FilterBarText = #414141
     $FilterBarTextHover = Black
     $FilterBarActive = GreenD
-    
+
     $SearchBoxBg = Grey
 
     $DropDownBg = White
@@ -52,23 +52,23 @@
     $DropDownTextHover = Black
     $DropDownText = #373737
     $DropDownOpacity = 0.97
-    
+
     $FilterBarIcon = $Text2
     $FilterBarIconHover = GreenD
     $FilterBarIcon-PosterWidth = $Text4
 
     $TopBarShadow = 0px 6px 8px -4px rgba(0, 0, 0, .9);
-    
+
 //Buttons
     $ButtonBg = #00a300
     $ButtonBgHover = #00b700
     $ButtonBgActive = #008f00
-    
+
     $ButtonBgDisabled = #d8d8d8
 
     $ButtonBgOk = #27AE60
     $ButtonBgWarning = #F15153
-    
+
     $ButtonText = #fff
     $ButtonTextHover = #fff
 
@@ -77,13 +77,13 @@
 //Checkbox
     $CheckboxBg = #d8d8d8
     $CheckboxCheck = GreenD
-    
+
 //Posters
     $PosterRadius = 4px
     $PosterHoverBorder = GreenL
     $PosterHoverOverlay = rgba(23, 24, 27, 0.6)
     $PosterShadow = 0px 0px 10px
-    
+
 //TV Series
     $ShowBgColor1 = $BgColor1
     $ShowBgColor2 = $BgColor2
@@ -115,14 +115,15 @@
 
     $InputBoxBg = #d8d8d8
     $InputBoxText = $Text1
-    
+
     $SettingsText1 = $Text1
     $SettingsText2 = $Text4
 
     $SettingsButtonText = $ButtonText
     $SettingsButtonTextHover = $ButtonText
 
-    $QualitySelector = $ButtonBg
+    $QualitySelectorBg = $ButtonBg
+    $QualitySelectorText = $ButtonText
 
 // Notifications
     $NotificationText = #fff
@@ -144,8 +145,8 @@
     $WarningColor = #A52A2A
     $PngLogo = brightness(0.3)
     $PngLogo_BgColo1 = brightness(0.3)
-    
-//Player 
+
+//Player
     $PlayerColor = GreenL
 
 

--- a/src/app/styl/views/show_detail.styl
+++ b/src/app/styl/views/show_detail.styl
@@ -462,7 +462,7 @@
                 padding: 10px 0
 
                 .sdow-quality
-                    margin-top: 24px
+                    margin-top: 20px
                     float: left
 
                     div
@@ -473,6 +473,7 @@
                         font-size: 11px
                         color: $ShowText1
                         transition: all .2s ease-in
+                        padding: 4px
 
                     .q720
                         margin-left: 6px
@@ -487,7 +488,9 @@
                     .active
                         cursor: pointer
                         opacity: 1
-                        color: $QualitySelector
+                        color: $QualitySelectorText
+                        background: $QualitySelectorBg
+                        border-radius: 10px
                         font-family: $MainFontBold
 
                 .sdow-watchnow


### PR DESCRIPTION
https://github.com/popcorn-official/popcorn-desktop/issues/306

This is an issue created in PCT project and is actually closed but at begin they was a bit interested

Changes proposed in this pull request:
- Add a rounds corners background around the selected/choosed quality.
- Should improve a bit UX.

I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)


PS: my editor removed some whitespaces too