### PR TITLE
make sure posterCache.onload only gets called once

### DIFF
--- a/src/app/lib/views/browser/item.js
+++ b/src/app/lib/views/browser/item.js
@@ -132,6 +132,8 @@
             posterCache.src = poster;
 
             posterCache.onload = function () {
+                posterCache.onload = () => {};
+
                 if (poster.indexOf('.gif') !== -1) { // freeze gifs
                     var c = document.createElement('canvas');
                     var w  = c.width = posterCache.width;


### PR DESCRIPTION
Poster cache is currently ifinitely looping canvases calls.