### PR TITLE
Urgent: Fix nwjs build system on macOS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,8 @@
  ********/
 const nwVersion = '0.18.6',
     nwFlavor = 'sdk',
-    availablePlatforms = ['linux32', 'linux64', 'win32', 'osx32'],
+    // nwjs for osx32 was discontinued in 0.12.0 (Mar 5, 2015).
+    availablePlatforms = ['linux32', 'linux64', 'win32', 'osx64'],
     releasesDir = 'build';
 
 
@@ -45,12 +46,9 @@ const parsePlatforms = () => {
         }
     }
 
-    // for osx and win, 32-bits works on 64, if needed
+    // for win, 32-bits works on 64, if needed
     if (availablePlatforms.indexOf('win64') === -1 && requestedPlatforms.indexOf('win64') !== -1) {
         validPlatforms.push('win32');
-    }
-    if (availablePlatforms.indexOf('osx64') === -1 && requestedPlatforms.indexOf('osx64') !== -1) {
-        validPlatforms.push('osx32');
     }
 
     // remove duplicates


### PR DESCRIPTION
This is an urgent fix to be able to get more macOS developers on the project. It fixes the broken build system, which hasn't worked for **a year and half** on Mac!

The old build system forces Mac builds to use "osx32" for nwjs.

For osx, _only_ 64-bit nwjs exists. There is no 32-bit nwjs anymore. It was abandoned in nwjs 0.12.0 (Mar 5, 2015), probably because Apple hasn't made 32-bit Macs for over a decade. We are now at nwjs 0.18.6. 🤕 

That's a long time for Mac builds to not have worked! So casual developers haven't been able to try contributing even if they wanted to, since it hasn't been possible to build Butter.

Related issue: https://github.com/nwjs/nw-builder/issues/363

"The 32 bit version works but only has old legacy versions and it is not and probably won't be supported anymore." -- DblK @ nw-builder

So trying to build as osx32 would totally fail since it has no new nwjs versions.

This is the error if you try to build Butter with osx32 of nwjs:

```
[08:17:08] Starting 'nwjs'...
Using v0.18.6 (sdk)
Error: Unsupported NW.js version '0.18.6 (sdk)' for platform 'osx32'
```

I've fixed that problem. It now builds using the latest nwjs 64-bit, which is the _only_ available CPU architecture of nwjs for macOS.

-----------
I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)