### PR TITLE
Changing GitLab anchor

### DIFF
--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -2,6 +2,7 @@
 var Settings = {
     projectName: 'Butter',
     projectUrl: 'http://butterproject.org',
+    projectGitLab: 'https://gitlab.com/butterproject',
     projectTwitter: 'butterproject',
     projectFacebook: 'ButterProjectOrg',
     projectGooglePlus: 'ButterProject',

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -2,7 +2,6 @@
 var Settings = {
     projectName: 'Butter',
     projectUrl: 'http://butterproject.org',
-    projectGitLab: 'https://gitlab.com/butterproject',
     projectTwitter: 'butterproject',
     projectFacebook: 'ButterProjectOrg',
     projectGooglePlus: 'ButterProject',

--- a/src/app/styl/views/about.styl
+++ b/src/app/styl/views/about.styl
@@ -9,7 +9,7 @@
     background-image url('../images/bg-header.jpg')
     background-size cover
     background-position 50% 50%
-    
+
     .margintop
         height calc(20% - 20px)
 
@@ -60,7 +60,7 @@
             margin 0 auto
             max-width 42em
             font-size 1em
-            
+
             .full-text
                 height 90px
 
@@ -90,27 +90,27 @@
             a.twitter_icon
                 background url(../images/icons/icon-twitter.png) no-repeat center
                 background-size contain
-                
+
             a.facebook_icon
                 background url(../images/icons/icon-facebook.png) no-repeat center
                 background-size contain
-                
+
             a.google_icon
                 background url(../images/icons/icon-google.png) no-repeat center
                 background-size contain
-                
+
             a.stash_icon
                 background url(../images/icons/icon-stash.png) no-repeat center
                 background-size contain
 
-            a.gitlab_icon
-                background url(../images/icons/icon-gitlab.png) no-repeat center
+            a.github_icon
+                background url(../images/icons/icon-github.png) no-repeat center
                 background-size contain
 
             a.blog_icon
                 background url(../images/icons/icon-blog.png) no-repeat center
                 background-size contain
-                
+
             a.forum_icon
                 background url(../images/icons/icon-discourse.png) no-repeat center
                 background-size contain

--- a/src/app/templates/about.tpl
+++ b/src/app/templates/about.tpl
@@ -24,7 +24,7 @@
             <a href='http://twitter.com/<%= Settings.projectTwitter %>' data-toggle="tooltip" data-placement="top" title="twitter.com/<%= Settings.projectTwitter %>" class='links twitter_icon'></span></a>
             <a href='http://www.fb.com/<%= Settings.projectFacebook %>' data-toggle="tooltip" data-placement="top" title="fb.com/<%= Settings.projectFacebook %>" class='links facebook_icon'></span></a>
             <a href='http://plus.google.com/+<%= Settings.projectGooglePlus %>/posts' data-toggle="tooltip" data-placement="top" title="plus.google.com/+<%= Settings.projectGooglePlus %>" class='links google_icon'></span></a>
-            <a href='<%= Settings.projectGitLab %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectGitLab %>" class='links gitlab_icon'></span></a>
+            <a href='<%= Settings.sourceUrl %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.sourceUrl %>" class='links github_icon'></span></a>
             <a href='<%= Settings.projectBlog %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectBlog %>" class='links blog_icon'></span></a>
             <a href='<%= Settings.projectForum %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectForum %>" class='links forum_icon'></span></a>
         </div>

--- a/src/app/templates/about.tpl
+++ b/src/app/templates/about.tpl
@@ -24,7 +24,7 @@
             <a href='http://twitter.com/<%= Settings.projectTwitter %>' data-toggle="tooltip" data-placement="top" title="twitter.com/<%= Settings.projectTwitter %>" class='links twitter_icon'></span></a>
             <a href='http://www.fb.com/<%= Settings.projectFacebook %>' data-toggle="tooltip" data-placement="top" title="fb.com/<%= Settings.projectFacebook %>" class='links facebook_icon'></span></a>
             <a href='http://plus.google.com/+<%= Settings.projectGooglePlus %>/posts' data-toggle="tooltip" data-placement="top" title="plus.google.com/+<%= Settings.projectGooglePlus %>" class='links google_icon'></span></a>
-            <a href='<%= Settings.projectUrl %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectUrl %>" class='links gitlab_icon'></span></a>
+            <a href='<%= Settings.projectGitLab %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectUrl %>" class='links gitlab_icon'></span></a>
             <a href='<%= Settings.projectBlog %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectBlog %>" class='links blog_icon'></span></a>
             <a href='<%= Settings.projectForum %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectForum %>" class='links forum_icon'></span></a>
         </div>
@@ -36,6 +36,6 @@
     </div>
     <div class="changelog-overlay">
         <div class="title"><%=i18n.__("Changelog")%></div>
-        <div class="changelog-text"></div>    
+        <div class="changelog-text"></div>
     </div>
 </div>

--- a/src/app/templates/about.tpl
+++ b/src/app/templates/about.tpl
@@ -24,7 +24,7 @@
             <a href='http://twitter.com/<%= Settings.projectTwitter %>' data-toggle="tooltip" data-placement="top" title="twitter.com/<%= Settings.projectTwitter %>" class='links twitter_icon'></span></a>
             <a href='http://www.fb.com/<%= Settings.projectFacebook %>' data-toggle="tooltip" data-placement="top" title="fb.com/<%= Settings.projectFacebook %>" class='links facebook_icon'></span></a>
             <a href='http://plus.google.com/+<%= Settings.projectGooglePlus %>/posts' data-toggle="tooltip" data-placement="top" title="plus.google.com/+<%= Settings.projectGooglePlus %>" class='links google_icon'></span></a>
-            <a href='<%= Settings.projectGitLab %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectUrl %>" class='links gitlab_icon'></span></a>
+            <a href='<%= Settings.projectGitLab %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectGitLab %>" class='links gitlab_icon'></span></a>
             <a href='<%= Settings.projectBlog %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectBlog %>" class='links blog_icon'></span></a>
             <a href='<%= Settings.projectForum %>' data-toggle="tooltip" data-placement="top" title="<%= Settings.projectForum %>" class='links forum_icon'></span></a>
         </div>


### PR DESCRIPTION
Fixes 1 .  


Changes proposed in this pull request: 

**Issue** - At the about page, the GitLab's link was pointing to the project main page. Doesn't have sense to have a GitLab's link that goes to the same page that the "Pochoclin" link. So either we delete the GitLab's link, or we point it to the GitLab's Group. 
**My resolution** - To link the GitLab's icon to the GitLab Group. 
**My changes** - Add a key at settings.js, named projectGitLab, with value 'https://gitlab.com/butterproject', Change the href and title with '<%= Settings.projectGitLab %>' of the GitLab's link.  

I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)