### PR TITLE
removed unworking line which I believe tried to focus on the first re…

### DIFF
--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -286,7 +286,6 @@
             $('.items').attr('tabindex', '1');
             _.defer(function () {
                 self.checkFetchMore();
-                self.$('.items:first').focus();
             });
 
         },


### PR DESCRIPTION
## Fixes
fixed issue where after searching for a movie/show/etc hitting CTRL+F would result on focusing on the search-bar for only a split second (then the focus would move the `$(".items")` div which would not do anything (if focusing on the first result after search was meant in that line of code, it did not happen, it would focus on the parent div which does nothing but interfere with the search bar focus).

removing that focus line solves the focusing on the search bar.

### notes for reproducing the bug
- do not use the mouse at any point (focus should stay on that `$(".items")` div)
- hit CTRL+F and search something
- after u got the results (or no results at all), try hitting CTRL+F again and searching for something else

I've read the [Contributor License Agreement](/CONTRIBUTING.md#contributor-license-agreement)