### PR TITLE
fix for #649

### DIFF
--- a/src/app/lib/views/browser/list.js
+++ b/src/app/lib/views/browser/list.js
@@ -145,6 +145,7 @@
                 loadmore.children('.loading-container').css('display', 'none');
             }
 
+            this.selectFirstItem();
         },
 
         onError: function () {
@@ -254,8 +255,13 @@
             $('.item.selected .cover').click();
         },
 
+        selectFirstItem: function () {
+            var firstItem = $('.items').find('.item:visible:first');
+            this.selectItem(null, $(firstItem));
+        },
+
         selectItem: function (prev, next) {
-            prev.removeClass('selected');
+            prev && prev.removeClass('selected');
             next.addClass('selected');
 
             if (!Common.isElementInViewport(next)) {


### PR DESCRIPTION
- adds selectFirstItem to onLoaded() > when list is loaded with items,
  selects the first one
- selectFirstItem using item:visible:first > allows eventual hidden items
  (like display:none) not to be selected. might be overkill, but we can't
  be sure what the future holds

Fixes #649 